### PR TITLE
[BUGFIX] Fix print link

### DIFF
--- a/Resources/Private/Partials/Elements/PrintLink.html
+++ b/Resources/Private/Partials/Elements/PrintLink.html
@@ -4,7 +4,7 @@
 		<!-- theme_bootstrap: Partials/Elements/PrintLink.html [begin] -->
 
 		<li id="partialElementsPrintLinkLink">
-			<a href="javascript:alert('PRINT!!!')"><f:translate key="printLink_label" /></a>
+			<a href="javascript:print()"><f:translate key="printLink_label" /></a>
 		</li>
 
 		<!-- theme_bootstrap: Partials/Elements/PrintLink.html [end] -->


### PR DESCRIPTION
Instead of alerting "PRINT!!!" in the print link the print() method
is called.
