### PR TITLE
Changes for news version 5.x

### DIFF
--- a/Resources/Private/Extensions/News/Partials/List/Item.html
+++ b/Resources/Private/Extensions/News/Partials/List/Item.html
@@ -1,4 +1,4 @@
-{namespace n=Tx_News_ViewHelpers}<!--
+{namespace n=GeorgRinger\News\ViewHelpers}<!--
 	=====================
 		Partials/List/Item.html
 -->
@@ -118,8 +118,9 @@
 		<p>
 			<!-- date -->
 			<span class="news-list-date">
-				<time datetime="{f:format.date(date:newsItem.datetime,format:'Y-m-d')}">
-					<n:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</n:format.date>
+				<time datetime="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}">
+					<f:format.date format="{f:translate(key:'dateFormat')}">{newsItem.datetime}</f:format.date>
+					<meta itemprop="datePublished" content="{f:format.date(date:newsItem.datetime, format:'Y-m-d')}" />
 				</time>
 			</span>
 


### PR DESCRIPTION
- Changed namespace in head of file
- changed datetime-viewhelper (<n:format:date /> was removed)
  https://docs.typo3.org/typo3cms/extensions/news/Misc/Changelog/5-0-0.html#viewhelpers
