### PR TITLE
Replace "config.prefixLocalAnchors"

### DIFF
--- a/Configuration/TypoScript/Library/plugin.realurl.setupts
+++ b/Configuration/TypoScript/Library/plugin.realurl.setupts
@@ -1,3 +1,3 @@
-config.prefixLocalAnchors = all
+config.absRefPrefix = {$themes.configuration.baseurl}
 config.tx_realurl_enable = 1
 config.simulateStaticDocuments = 0


### PR DESCRIPTION
`config.prefixLocalAnchors` is deprecated since TYPO3 7.2 and should be replaced by `config.absRefPrefix`
(https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.2/Deprecation-65934-PrefixLocalAnchorsMovedToLegacyExtension.html)